### PR TITLE
JDAT-2: Moved encoded utils to jcommons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ JCommons is available on [Maven Central](http://search.maven.org/#search). You j
 <dependency>
   <groupId>com.adtsw</groupId>
   <artifactId>jcommons</artifactId>
-  <version>1.0.9</version>
+  <version>1.0.10</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.adtsw</groupId>
     <artifactId>jcommons</artifactId>
-    <version>1.0.9</version>
+    <version>1.0.10</version>
     
     <url>github.com/AdityaPawade/jcommons</url>
     <scm>

--- a/src/main/java/com/adtsw/jcommons/models/EncodingFormat.java
+++ b/src/main/java/com/adtsw/jcommons/models/EncodingFormat.java
@@ -1,6 +1,6 @@
 package com.adtsw.jcommons.models;
 
-public enum StorageFormat {
+public enum EncodingFormat {
 
     STRING, GZIP_WITH_BASE64
 }

--- a/src/main/java/com/adtsw/jcommons/models/StorageFormat.java
+++ b/src/main/java/com/adtsw/jcommons/models/StorageFormat.java
@@ -1,0 +1,6 @@
+package com.adtsw.jcommons.models;
+
+public enum StorageFormat {
+
+    STRING, GZIP_WITH_BASE64
+}

--- a/src/main/java/com/adtsw/jcommons/utils/EncoderUtil.java
+++ b/src/main/java/com/adtsw/jcommons/utils/EncoderUtil.java
@@ -1,0 +1,42 @@
+package com.adtsw.jcommons.utils;
+
+import com.adtsw.jcommons.models.StorageFormat;
+
+import java.io.IOException;
+
+public class EncoderUtil {
+
+    public static String encode(StorageFormat storageFormat, String payload) {
+        String encodedPayload = null;
+        switch (storageFormat) {
+            case STRING:
+                encodedPayload = payload;
+                break;
+            case GZIP_WITH_BASE64:
+                try {
+                    encodedPayload = CompressionUtil.compress(payload);
+                } catch (IOException e) {
+                    throw new RuntimeException(e.getMessage());
+                }
+                break;
+        }
+        return encodedPayload;
+    }
+
+    public static String decode(StorageFormat storageFormat, String storedPayload) {
+        String decodedPayload = null;
+        switch (storageFormat) {
+            case STRING:
+                decodedPayload = storedPayload;
+                break;
+            case GZIP_WITH_BASE64:
+                try {
+                    decodedPayload = CompressionUtil.decompress(storedPayload);
+                } catch (IOException e) {
+                    throw new RuntimeException(e.getMessage());
+                }
+                break;
+        }
+        return decodedPayload;
+    }
+}

--- a/src/main/java/com/adtsw/jcommons/utils/EncoderUtil.java
+++ b/src/main/java/com/adtsw/jcommons/utils/EncoderUtil.java
@@ -1,12 +1,12 @@
 package com.adtsw.jcommons.utils;
 
-import com.adtsw.jcommons.models.StorageFormat;
+import com.adtsw.jcommons.models.EncodingFormat;
 
 import java.io.IOException;
 
 public class EncoderUtil {
 
-    public static String encode(StorageFormat storageFormat, String payload) {
+    public static String encode(EncodingFormat storageFormat, String payload) {
         String encodedPayload = null;
         switch (storageFormat) {
             case STRING:
@@ -23,7 +23,7 @@ public class EncoderUtil {
         return encodedPayload;
     }
 
-    public static String decode(StorageFormat storageFormat, String storedPayload) {
+    public static String decode(EncodingFormat storageFormat, String storedPayload) {
         String decodedPayload = null;
         switch (storageFormat) {
             case STRING:

--- a/src/test/java/com/adtsw/jcommons/ds/SortedHashMapTest.java
+++ b/src/test/java/com/adtsw/jcommons/ds/SortedHashMapTest.java
@@ -1,6 +1,5 @@
 package com.adtsw.jcommons.ds;
 
-import com.adtsw.jcommons.utils.EncryptionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/com/adtsw/jcommons/metrics/MetricsRegistryTest.java
+++ b/src/test/java/com/adtsw/jcommons/metrics/MetricsRegistryTest.java
@@ -1,6 +1,5 @@
 package com.adtsw.jcommons.metrics;
 
-import com.adtsw.jcommons.utils.EncryptionUtil;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/src/test/java/com/adtsw/jcommons/utils/EncoderUtilTest.java
+++ b/src/test/java/com/adtsw/jcommons/utils/EncoderUtilTest.java
@@ -1,6 +1,6 @@
 package com.adtsw.jcommons.utils;
 
-import com.adtsw.jcommons.models.StorageFormat;
+import com.adtsw.jcommons.models.EncodingFormat;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -12,25 +12,25 @@ public class EncoderUtilTest {
 
     @Test
     public void testEncodeGZipSuccess() {
-        String encodedString = EncoderUtil.encode(StorageFormat.GZIP_WITH_BASE64, DECODED_STRING);
+        String encodedString = EncoderUtil.encode(EncodingFormat.GZIP_WITH_BASE64, DECODED_STRING);
         Assert.assertEquals(GZIP_ENCODED_STRING, encodedString);
     }
 
     @Test
     public void testEncodeStringSuccess() {
-        String encodedString = EncoderUtil.encode(StorageFormat.STRING, DECODED_STRING);
+        String encodedString = EncoderUtil.encode(EncodingFormat.STRING, DECODED_STRING);
         Assert.assertEquals(BASIC_ENCODED_STRING, encodedString);
     }
 
     @Test
     public void testDecodeGZipSuccess() {
-        String decodedString = EncoderUtil.decode(StorageFormat.GZIP_WITH_BASE64, GZIP_ENCODED_STRING);
+        String decodedString = EncoderUtil.decode(EncodingFormat.GZIP_WITH_BASE64, GZIP_ENCODED_STRING);
         Assert.assertEquals(DECODED_STRING, decodedString);
     }
 
     @Test
     public void testDecodeSuccess() {
-        String decodedString = EncoderUtil.decode(StorageFormat.STRING, BASIC_ENCODED_STRING);
+        String decodedString = EncoderUtil.decode(EncodingFormat.STRING, BASIC_ENCODED_STRING);
         Assert.assertEquals(DECODED_STRING, decodedString);
     }
 }

--- a/src/test/java/com/adtsw/jcommons/utils/EncoderUtilTest.java
+++ b/src/test/java/com/adtsw/jcommons/utils/EncoderUtilTest.java
@@ -1,0 +1,36 @@
+package com.adtsw.jcommons.utils;
+
+import com.adtsw.jcommons.models.StorageFormat;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EncoderUtilTest {
+
+    private final String GZIP_ENCODED_STRING = "H4sIAAAAAAAAACsuKcrMSwcAqbK+ngYAAAA=";
+    private final String BASIC_ENCODED_STRING = "string";
+    private final String DECODED_STRING = "string";
+
+    @Test
+    public void testEncodeGZipSuccess() {
+        String encodedString = EncoderUtil.encode(StorageFormat.GZIP_WITH_BASE64, DECODED_STRING);
+        Assert.assertEquals(GZIP_ENCODED_STRING, encodedString);
+    }
+
+    @Test
+    public void testEncodeStringSuccess() {
+        String encodedString = EncoderUtil.encode(StorageFormat.STRING, DECODED_STRING);
+        Assert.assertEquals(BASIC_ENCODED_STRING, encodedString);
+    }
+
+    @Test
+    public void testDecodeGZipSuccess() {
+        String decodedString = EncoderUtil.decode(StorageFormat.GZIP_WITH_BASE64, GZIP_ENCODED_STRING);
+        Assert.assertEquals(DECODED_STRING, decodedString);
+    }
+
+    @Test
+    public void testDecodeSuccess() {
+        String decodedString = EncoderUtil.decode(StorageFormat.STRING, BASIC_ENCODED_STRING);
+        Assert.assertEquals(DECODED_STRING, decodedString);
+    }
+}


### PR DESCRIPTION
Moved encoder utils to jcommons which is being used in JDataLayer repo